### PR TITLE
PORTALS-2731, PORTALS-2542 - SynapseTable column header icon fixes

### DIFF
--- a/packages/synapse-react-client/src/assets/mui_components/Docker.tsx
+++ b/packages/synapse-react-client/src/assets/mui_components/Docker.tsx
@@ -3,7 +3,7 @@ import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon'
 
 const Docker = (props: SvgIconProps) => {
   return (
-    <SvgIcon {...props}>
+    <SvgIcon viewBox="-2 0 26 17" {...props}>
       <path
         d="M9.80371 2.02862V0.25H11.5823V2.02862H9.80371Z"
         fillOpacity="0.3"

--- a/packages/synapse-react-client/src/assets/mui_components/PackagableFile.tsx
+++ b/packages/synapse-react-client/src/assets/mui_components/PackagableFile.tsx
@@ -3,7 +3,7 @@ import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon'
 
 const PackagableFile = (props: SvgIconProps) => {
   return (
-    <SvgIcon {...props}>
+    <SvgIcon viewBox="-4 -1 30 20" {...props}>
       <path d="M20.25 2.25H11.25L9 0H2.25C1.0125 0 0 1.0125 0 2.25V15.75C0 16.9875 1.0125 18 2.25 18H20.25C21.4875 18 22.5 16.9875 22.5 15.75V4.5C22.5 3.2625 21.4875 2.25 20.25 2.25ZM18 9H15.75V11.25H18V13.5H15.75V15.75H13.5V13.5H15.75V11.25H13.5V9H15.75V6.75H13.5V4.5H15.75V6.75H18V9Z" />
     </SvgIcon>
   )

--- a/packages/synapse-react-client/src/assets/themed_icons/SortDown.tsx
+++ b/packages/synapse-react-client/src/assets/themed_icons/SortDown.tsx
@@ -1,17 +1,14 @@
 import React from 'react'
+import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon'
 
-export const SortDown = () => (
-  <svg
+export const SortDown = (props: SvgIconProps) => (
+  <SvgIcon
     data-icon="sort-down"
-    width="21"
-    height="17"
-    viewBox="0 0 21 17"
+    viewBox="-3 0 27 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
-    <path
-      d="M8.5 9V7H16.5V9H8.5ZM8.5 15V13H12.5V15H8.5ZM8.5 3V1H20.5V3H8.5ZM4.5 13H7L3.5 16.5L0 13H2.5V0H4.5V13Z"
-      fill="#47337D"
-    />
-  </svg>
+    <path d="M8.5 9V7H16.5V9H8.5ZM8.5 15V13H12.5V15H8.5ZM8.5 3V1H20.5V3H8.5ZM4.5 13H7L3.5 16.5L0 13H2.5V0H4.5V13Z" />
+  </SvgIcon>
 )

--- a/packages/synapse-react-client/src/assets/themed_icons/SortUp.tsx
+++ b/packages/synapse-react-client/src/assets/themed_icons/SortUp.tsx
@@ -1,17 +1,14 @@
 import React from 'react'
+import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon'
 
-export const SortUp = () => (
-  <svg
+export const SortUp = (props: SvgIconProps) => (
+  <SvgIcon
     data-icon="sort-up"
-    width="21"
-    height="17"
-    viewBox="0 0 21 17"
+    viewBox="-3 0 27 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
-    <path
-      d="M8.5 7.5V9.5H16.5V7.5H8.5ZM8.5 1.5V3.5H12.5V1.5H8.5ZM8.5 13.5V15.5H20.5V13.5H8.5ZM4.5 3.5H7L3.5 0L0 3.5H2.5V16.5H4.5V3.5Z"
-      fill="#47337D"
-    />
-  </svg>
+    <path d="M8.5 7.5V9.5H16.5V7.5H8.5ZM8.5 1.5V3.5H12.5V1.5H8.5ZM8.5 13.5V15.5H20.5V13.5H8.5ZM4.5 3.5H7L3.5 0L0 3.5H2.5V16.5H4.5V3.5Z" />
+  </SvgIcon>
 )

--- a/packages/synapse-react-client/src/components/DownloadCart/DownloadDetails.tsx
+++ b/packages/synapse-react-client/src/components/DownloadCart/DownloadDetails.tsx
@@ -3,6 +3,7 @@ import { calculateFriendlyFileSize } from '../../utils/functions/calculateFriend
 import { TOOLTIP_DELAY_SHOW } from '../SynapseTable/SynapseTableConstants'
 import IconSvg from '../IconSvg/IconSvg'
 import { Tooltip } from '@mui/material'
+import pluralize from 'pluralize'
 
 export type DownloadDetailsProps = {
   numFiles: number
@@ -17,13 +18,22 @@ export default function DownloadDetails(props: DownloadDetailsProps) {
   const iconClassName = isInactive ? 'SRC-inactive' : 'SRC-primary-text-color'
   return (
     <span className="DownloadDetailsV2">
-      <span className="item">{!isInactive && <> {numFiles} Files </>}</span>
+      <span className="item">
+        {!isInactive && (
+          <>
+            {numFiles.toLocaleString()} {pluralize('File', numFiles)}
+          </>
+        )}
+      </span>
       <span className="item">
         <span className={iconClassName}>
-          <IconSvg icon="packagableFile" />
+          <IconSvg wrap={false} icon="packagableFile" />
         </span>
         {!isInactive && (
-          <> {numPackagableFiles} Files eligible for packaging </>
+          <>
+            {numPackagableFiles.toLocaleString()}{' '}
+            {pluralize('File', numPackagableFiles)} eligible for packaging
+          </>
         )}
       </span>
       {numBytes > 0 && (
@@ -41,7 +51,10 @@ export default function DownloadDetails(props: DownloadDetailsProps) {
             <IconSvg icon="warningOutlined" />
           </span>
           {!isInactive && (
-            <> {numIneligibleFiles} Files ineligible for packaging </>
+            <>
+              {numIneligibleFiles.toLocaleString()}{' '}
+              {pluralize('File', numIneligibleFiles)} ineligible for packaging
+            </>
           )}
         </span>
       )}

--- a/packages/synapse-react-client/src/components/DownloadCart/DownloadListTable.tsx
+++ b/packages/synapse-react-client/src/components/DownloadCart/DownloadListTable.tsx
@@ -276,7 +276,7 @@ export default function DownloadListTable(props: DownloadListTableProps) {
                             placement="right"
                           >
                             <span className="eligibileIcon">
-                              <IconSvg icon="packagableFile" />
+                              <IconSvg wrap={false} icon="packagableFile" />
                             </span>
                           </Tooltip>
                         )}
@@ -287,7 +287,7 @@ export default function DownloadListTable(props: DownloadListTableProps) {
                             placement="right"
                           >
                             <span className="ineligibileIcon">
-                              <IconSvg icon="warningOutlined" />
+                              <IconSvg wrap={false} icon="warningOutlined" />
                             </span>
                           </Tooltip>
                         )}

--- a/packages/synapse-react-client/src/components/DownloadCart/DownloadListTable.tsx
+++ b/packages/synapse-react-client/src/components/DownloadCart/DownloadListTable.tsx
@@ -228,6 +228,7 @@ export default function DownloadListTable(props: DownloadListTableProps) {
                 <th>
                   SynID
                   <InteractiveCopyIdsIcon
+                    size={'small'}
                     onCopy={() => {
                       // trigger loading all pages of the download list table, and then copy all IDs to the clipboard
                       setCopyingAllSynapseIDs(true)

--- a/packages/synapse-react-client/src/components/IconSvg/IconSvg.tsx
+++ b/packages/synapse-react-client/src/components/IconSvg/IconSvg.tsx
@@ -114,8 +114,10 @@ import PackagableFile from '../../assets/mui_components/PackagableFile'
 import Proteomics from '../../assets/mui_components/Proteomics'
 import Rat from '../../assets/mui_components/Rat'
 import { EntityType } from '@sage-bionetworks/synapse-types'
-import { SxProps, Tooltip } from '@mui/material'
+import { Tooltip } from '@mui/material'
 import CreateVersion from '../../assets/icons/CreateVersion'
+import { SvgIconProps } from '@mui/material/SvgIcon/SvgIcon'
+import { SortDown, SortUp } from '../../assets/themed_icons'
 
 export const IconStrings = [
   'accessOpen',
@@ -235,6 +237,8 @@ export const IconStrings = [
   'createVersion',
   'email',
   'addConditions',
+  'sortUp',
+  'sortDown',
 ] as const
 
 export type IconName = (typeof IconStrings)[number]
@@ -243,260 +247,263 @@ export type IconSvgProps = {
   icon: IconName
   // If provided, will be shown in tooltip
   label?: string
-  sx?: SxProps
   wrap?: boolean
-}
+} & SvgIconProps
 
-function IconMapping(props: { icon: string; sx?: SxProps }) {
-  const { icon } = props
+function IconMapping(props: { icon: string } & SvgIconProps) {
+  const { icon, ...otherProps } = props
   const color = undefined
 
-  const sx: SxProps = {
+  otherProps.sx = {
     verticalAlign: 'middle',
-    ...props.sx,
+    ...otherProps.sx,
   }
 
   switch (icon) {
     case 'accessOpen':
-      return <LockOpenTwoTone sx={sx} />
+      return <LockOpenTwoTone {...otherProps} />
     case 'accessClosed':
-      return <VpnKeyTwoTone sx={sx} />
+      return <VpnKeyTwoTone {...otherProps} />
     case 'add':
-      return <AddTwoTone sx={sx} />
+      return <AddTwoTone {...otherProps} />
     case 'addConditions':
-      return <FactCheckTwoTone sx={sx} />
+      return <FactCheckTwoTone {...otherProps} />
     case 'arrowBack':
-      return <ArrowBack sx={sx} />
+      return <ArrowBack {...otherProps} />
     case 'arrowForward':
-      return <ArrowForward sx={sx} />
+      return <ArrowForward {...otherProps} />
     case 'arrowDropUp':
-      return <ArrowDropUpTwoTone sx={sx} />
+      return <ArrowDropUpTwoTone {...otherProps} />
     case 'arrowDropDown':
-      return <ArrowDropDownTwoTone sx={sx} />
+      return <ArrowDropDownTwoTone {...otherProps} />
     case 'article':
-      return <ArticleTwoTone sx={sx} />
+      return <ArticleTwoTone {...otherProps} />
     case 'block':
-      return <Block sx={sx} />
+      return <Block {...otherProps} />
     case 'check':
-      return <Check sx={sx}></Check>
+      return <Check {...otherProps} />
     case 'clear':
-      return <Clear sx={sx}></Clear>
+      return <Clear {...otherProps} />
     case 'cart':
-      return <ShoppingCartOutlined sx={sx}></ShoppingCartOutlined>
+      return <ShoppingCartOutlined {...otherProps} />
     case 'cards':
-      return <ViewAgendaTwoTone sx={sx}></ViewAgendaTwoTone>
+      return <ViewAgendaTwoTone {...otherProps} />
     case 'clock':
-      return <AccessTimeTwoTone sx={sx} />
+      return <AccessTimeTwoTone {...otherProps} />
     case 'code':
-      return <Code sx={sx}></Code>
+      return <Code {...otherProps} />
     case 'columns':
-      return <ViewColumnTwoTone sx={sx}></ViewColumnTwoTone>
+      return <ViewColumnTwoTone {...otherProps} />
     case 'circle':
-      return <RadioButtonUncheckedTwoTone sx={sx} />
+      return <RadioButtonUncheckedTwoTone {...otherProps} />
     case 'checkCircle':
-      return <CheckCircleTwoTone sx={sx} />
+      return <CheckCircleTwoTone {...otherProps} />
     case 'createVersion':
-      return <CreateVersion sx={sx} />
+      return <CreateVersion {...otherProps} />
     case 'dashboard':
-      return <DashboardTwoTone sx={sx}></DashboardTwoTone>
+      return <DashboardTwoTone {...otherProps} />
     case 'delete':
-      return <DeleteTwoTone sx={sx} />
+      return <DeleteTwoTone {...otherProps} />
     case 'deleteSweep':
-      return <DeleteSweepTwoTone sx={sx} />
+      return <DeleteSweepTwoTone {...otherProps} />
     case 'openInNewWindow':
-      return <OpenInNewTwoTone sx={sx} />
+      return <OpenInNewTwoTone {...otherProps} />
     case 'phone':
-      return <PhoneTwoTone sx={sx} />
+      return <PhoneTwoTone {...otherProps} />
     case 'people':
-      return <PeopleTwoTone sx={sx} />
+      return <PeopleTwoTone {...otherProps} />
     case 'addToCart':
-      return <AddShoppingCart sx={sx}></AddShoppingCart>
+      return <AddShoppingCart {...otherProps} />
     case 'addCircleOutline':
-      return <AddCircleOutline sx={sx}></AddCircleOutline>
+      return <AddCircleOutline {...otherProps} />
     case 'addCircleTwoTone':
-      return <AddCircleTwoTone sx={sx}></AddCircleTwoTone>
+      return <AddCircleTwoTone {...otherProps} />
     case 'reload':
-      return <Cached sx={sx}></Cached>
+      return <Cached {...otherProps} />
     case 'team':
-      return <Group sx={sx}></Group>
+      return <Group {...otherProps} />
     case 'photoCamera':
-      return <PhotoCameraOutlined sx={sx}></PhotoCameraOutlined>
+      return <PhotoCameraOutlined {...otherProps} />
     case 'verticalEllipsis':
-      return <MoreVertTwoTone sx={sx} />
+      return <MoreVertTwoTone {...otherProps} />
     case 'sync':
-      return <SyncTwoTone sx={sx} />
+      return <SyncTwoTone {...otherProps} />
     case 'public':
-      return <PublicTwoTone sx={sx} />
+      return <PublicTwoTone {...otherProps} />
     case 'clipboard':
-      return <AssignmentOutlined sx={sx} />
+      return <AssignmentOutlined {...otherProps} />
     case 'clipboardCheck':
-      return <AssignmentTurnedInTwoTone sx={sx} />
+      return <AssignmentTurnedInTwoTone {...otherProps} />
     case 'info':
-      return <InfoOutlined sx={sx}></InfoOutlined>
+      return <InfoOutlined {...otherProps} />
     case 'favTwoTone':
-      return <StarTwoTone sx={sx}></StarTwoTone>
+      return <StarTwoTone {...otherProps} />
     case 'favOutline':
-      return <StarOutline sx={sx}></StarOutline>
+      return <StarOutline {...otherProps} />
     case 'fav':
-      return <Star sx={sx}></Star>
+      return <Star {...otherProps} />
     case 'github':
-      return <GitHub sx={sx} />
+      return <GitHub {...otherProps} />
     case 'peopleTwoTone':
-      return <PeopleTwoTone sx={sx}></PeopleTwoTone>
+      return <PeopleTwoTone {...otherProps} />
     case 'challengesTwoTone':
-      return <AssessmentTwoTone sx={sx}></AssessmentTwoTone>
+      return <AssessmentTwoTone {...otherProps} />
     case 'download':
-      return <GetAppTwoTone sx={sx}></GetAppTwoTone>
+      return <GetAppTwoTone {...otherProps} />
     case 'errorOutlined':
-      return <ErrorOutlined sx={sx} />
+      return <ErrorOutlined {...otherProps} />
     case 'searchOutlined':
-      return <SearchOutlined sx={sx}></SearchOutlined>
+      return <SearchOutlined {...otherProps} />
     case 'search':
-      return <SearchTwoTone sx={sx}></SearchTwoTone>
+      return <SearchTwoTone {...otherProps} />
     case 'history':
-      return <HistoryTwoTone sx={sx}></HistoryTwoTone>
+      return <HistoryTwoTone {...otherProps} />
     case 'time':
-      return <WatchLater sx={sx}></WatchLater>
+      return <WatchLater {...otherProps} />
     case 'login':
-      return <Login sx={sx}></Login>
+      return <Login {...otherProps} />
     case 'helpOutlineTwoTone':
-      return <HelpOutlineTwoTone sx={sx}></HelpOutlineTwoTone>
+      return <HelpOutlineTwoTone {...otherProps} />
     case 'helpOutlined':
-      return <HelpOutlined sx={sx}></HelpOutlined>
+      return <HelpOutlined {...otherProps} />
     case 'close':
     case 'cross':
-      return <CloseTwoTone sx={sx} />
+      return <CloseTwoTone {...otherProps} />
     case 'expandLess':
-      return <ExpandLess sx={sx}></ExpandLess>
+      return <ExpandLess {...otherProps} />
     case 'expandMore':
-      return <ExpandMore sx={sx}></ExpandMore>
+      return <ExpandMore {...otherProps} />
     case 'rat':
-      return <Rat sx={sx}></Rat>
+      return <Rat {...otherProps} />
     case 'chromatin':
-      return <Chromatin sx={sx}></Chromatin>
+      return <Chromatin {...otherProps} />
     case 'clinical':
-      return <Clinical sx={sx}></Clinical>
+      return <Clinical {...otherProps} />
     case 'contentCopy':
-      return <ContentCopyTwoTone sx={sx} />
+      return <ContentCopyTwoTone {...otherProps} />
     case 'data':
-      return <Data sx={sx}></Data>
+      return <Data {...otherProps} />
     case 'dataLocked':
-      return <DataLocked sx={sx}></DataLocked>
+      return <DataLocked {...otherProps} />
     case 'geneExpression':
-      return <GeneExpression sx={sx}></GeneExpression>
+      return <GeneExpression {...otherProps} />
     case 'geneVariants':
-      return <GeneVariants sx={sx}></GeneVariants>
+      return <GeneVariants {...otherProps} />
     case 'imaging':
-      return <Imaging sx={sx}></Imaging>
+      return <Imaging {...otherProps} />
     case 'lineGraph':
-      return <LineGraph sx={sx}></LineGraph>
+      return <LineGraph {...otherProps} />
     case 'kinomics':
-      return <Kinomics sx={sx}></Kinomics>
+      return <Kinomics {...otherProps} />
     case 'proteomics':
-      return <Proteomics sx={sx}></Proteomics>
+      return <Proteomics {...otherProps} />
     case 'packagableFile':
-      return <PackagableFile sx={sx}></PackagableFile>
+      return <PackagableFile {...otherProps} />
     case 'other':
-      return <Other fill={color} sx={sx}></Other>
+      return <Other fill={color} {...otherProps} />
     case 'wiki':
-      return <LanguageTwoTone sx={sx} />
+      return <LanguageTwoTone {...otherProps} />
     case 'file':
-      return <InsertDriveFileTwoTone sx={sx} />
+      return <InsertDriveFileTwoTone {...otherProps} />
     case 'fileOutlined':
-      return <InsertDriveFileOutlined sx={sx} />
+      return <InsertDriveFileOutlined {...otherProps} />
     case 'folder':
-      return <FolderTwoTone sx={sx} />
+      return <FolderTwoTone {...otherProps} />
     case 'newFolder':
-      return <CreateNewFolderTwoTone sx={sx} />
+      return <CreateNewFolderTwoTone {...otherProps} />
     case 'link':
-      return <LinkTwoTone sx={sx} />
+      return <LinkTwoTone {...otherProps} />
     case 'table':
-      return <TableChartTwoTone sx={sx} />
+      return <TableChartTwoTone {...otherProps} />
     case 'entityview':
-      return <ListTwoTone sx={sx} />
+      return <ListTwoTone {...otherProps} />
     case 'submissionview':
-      return <StorageTwoTone sx={sx} />
+      return <StorageTwoTone {...otherProps} />
     case 'challenge':
-      return <AssessmentTwoTone sx={sx} />
+      return <AssessmentTwoTone {...otherProps} />
     case 'discussion':
-      return <QuestionAnswerTwoTone sx={sx} />
+      return <QuestionAnswerTwoTone {...otherProps} />
     case 'dataset':
-      return <Dataset sx={sx} />
+      return <Dataset {...otherProps} />
     case 'datasetcollection':
-      return <DatasetCollection sx={sx} />
+      return <DatasetCollection {...otherProps} />
     case 'database':
-      return <LayersTwoTone sx={sx} />
+      return <LayersTwoTone {...otherProps} />
     case 'docker':
-      return <Docker sx={sx} />
+      return <Docker {...otherProps} />
     case 'accountCertified':
-      return <AccountCertified sx={sx} />
+      return <AccountCertified {...otherProps} />
     case 'accountRegistered':
-      return <AccountRegistered sx={sx} />
+      return <AccountRegistered {...otherProps} />
     case 'accountValidated':
-      return <AccountValidated sx={sx} />
+      return <AccountValidated {...otherProps} />
     case 'warningOutlined':
-      return <ReportProblemOutlined sx={sx}></ReportProblemOutlined>
+      return <ReportProblemOutlined {...otherProps} />
     case 'warning':
-      return <WarningTwoTone sx={sx} />
+      return <WarningTwoTone {...otherProps} />
     case 'removeCircle':
-      return <RemoveCircleTwoTone sx={sx}></RemoveCircleTwoTone>
+      return <RemoveCircleTwoTone {...otherProps} />
     case 'replyTwoTone':
-      return <ReplyTwoTone sx={sx}></ReplyTwoTone>
+      return <ReplyTwoTone {...otherProps} />
     case 'chatTwoTone':
-      return <ChatTwoTone sx={sx}></ChatTwoTone>
+      return <ChatTwoTone {...otherProps} />
     case 'accessManagement':
-      return <AccessManagement sx={sx}></AccessManagement>
+      return <AccessManagement {...otherProps} />
     case 'chevronRight':
-      return <ChevronRight sx={sx} />
+      return <ChevronRight {...otherProps} />
     case 'chevronLeft':
-      return <ChevronLeft sx={sx} />
+      return <ChevronLeft {...otherProps} />
     case 'pushpin':
-      return <PushPinTwoTone sx={sx} />
+      return <PushPinTwoTone {...otherProps} />
     case 'addBoxOutline':
-      return <AddBoxOutlined sx={sx} />
+      return <AddBoxOutlined {...otherProps} />
     case 'minusBoxOutline':
-      return <IndeterminateCheckBoxOutlined sx={sx} />
+      return <IndeterminateCheckBoxOutlined {...otherProps} />
     case 'italic':
-      return <FormatItalic sx={sx} />
+      return <FormatItalic {...otherProps} />
     case 'bold':
-      return <FormatBold sx={sx} />
+      return <FormatBold {...otherProps} />
     case 'title':
-      return <Title sx={sx} />
+      return <Title {...otherProps} />
     case 'visibility':
-      return <VisibilityTwoTone sx={sx} />
+      return <VisibilityTwoTone {...otherProps} />
     case 'visibilityOff':
-      return <VisibilityOffTwoTone sx={sx} />
+      return <VisibilityOffTwoTone {...otherProps} />
     case 'strikethrough':
-      return <StrikethroughS sx={sx} />
+      return <StrikethroughS {...otherProps} />
     case 'latex':
       return <span>TeX</span>
     case 'image':
-      return <Image sx={sx} />
+      return <Image {...otherProps} />
     case 'superscript':
-      return <Superscript sx={sx} />
+      return <Superscript {...otherProps} />
     case 'subscript':
-      return <Subscript sx={sx} />
+      return <Subscript {...otherProps} />
     case 'edit':
-      return <EditTwoTone sx={sx} />
+      return <EditTwoTone {...otherProps} />
     case 'tag':
-      return <AlternateEmail sx={sx} />
+      return <AlternateEmail {...otherProps} />
     case 'restore':
-      return <RestoreFromTrashTwoTone sx={sx} />
+      return <RestoreFromTrashTwoTone {...otherProps} />
     case 'label':
-      return <LabelTwoTone sx={sx} />
+      return <LabelTwoTone {...otherProps} />
     case 'upload':
-      return <UploadTwoTone sx={sx} />
+      return <UploadTwoTone {...otherProps} />
     case 'flag':
-      return <FlagTwoTone sx={sx} />
+      return <FlagTwoTone {...otherProps} />
     case 'email':
-      return <MailOutlineTwoTone sx={sx} />
+      return <MailOutlineTwoTone {...otherProps} />
+    case 'sortUp':
+      return <SortUp {...otherProps} />
+    case 'sortDown':
+      return <SortDown {...otherProps} />
     default:
       return <></>
   }
 }
 
 function IconSvg(props: IconSvgProps) {
-  const { icon, label = '', sx, wrap = true } = props
+  const { icon, label = '', wrap = true, ...svgIconProps } = props
 
   const Wrapper = wrap ? 'span' : React.Fragment
   const wrapperProps = wrap
@@ -511,7 +518,7 @@ function IconSvg(props: IconSvgProps) {
   return (
     <Tooltip placement="top" title={label}>
       <Wrapper {...wrapperProps}>
-        <IconMapping icon={icon} sx={sx} />
+        <IconMapping icon={icon} {...svgIconProps} />
       </Wrapper>
     </Tooltip>
   )

--- a/packages/synapse-react-client/src/components/InteractiveCopyIdsIcon.tsx
+++ b/packages/synapse-react-client/src/components/InteractiveCopyIdsIcon.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
-import { IconButton, Tooltip } from '@mui/material'
+import { IconButton, IconButtonProps, Tooltip } from '@mui/material'
 import { TOOLTIP_DELAY_SHOW } from './SynapseTable/SynapseTableConstants'
 import IconSvg from './IconSvg/IconSvg'
 
-export type InteractiveCopyIdsIconProps = {
+export type InteractiveCopyIdsIconProps = Omit<IconButtonProps, 'onClick'> & {
   onCopy: () => void
 }
 
 export const InteractiveCopyIdsIcon = (props: InteractiveCopyIdsIconProps) => {
-  const { onCopy } = props
+  const { onCopy, ...buttonProps } = props
   return (
     <Tooltip
       title="Copy IDs to the clipboard"
@@ -16,11 +16,11 @@ export const InteractiveCopyIdsIcon = (props: InteractiveCopyIdsIconProps) => {
       placement="right"
     >
       <IconButton
-        sx={{ height: '40px' }}
         data-testid="copySynIdsButton"
+        {...buttonProps}
         onClick={onCopy}
       >
-        <IconSvg icon="contentCopy" />
+        <IconSvg wrap={false} icon="contentCopy" fontSize={'inherit'} />
       </IconButton>
     </Tooltip>
   )

--- a/packages/synapse-react-client/src/components/SynapseTable/EntityIDColumnCopyIcon.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/EntityIDColumnCopyIcon.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import { useQueryContext } from '../QueryContext/QueryContext'
 import { useSynapseContext } from '../../utils/context/SynapseContext'
-import { InteractiveCopyIdsIcon } from '../InteractiveCopyIdsIcon'
+import {
+  InteractiveCopyIdsIcon,
+  InteractiveCopyIdsIconProps,
+} from '../InteractiveCopyIdsIcon'
 import { displayToast } from '../ToastMessage/ToastMessage'
 import { QueryResultBundle, Row } from '@sage-bionetworks/synapse-types'
 import { SynapseSpinner } from '../LoadingScreen'
@@ -9,7 +12,9 @@ import { SynapseConstants } from '../../utils'
 import { getFullQueryTableResults } from '../../synapse-client/SynapseClient'
 import { parseEntityIdAndVersionFromSqlStatement } from '../../utils/functions/SqlFunctions'
 
-const EntityIDColumnCopyIcon = () => {
+type EntityIDColumnCopyIconProps = Omit<InteractiveCopyIdsIconProps, 'onCopy'>
+
+const EntityIDColumnCopyIcon = (props: EntityIDColumnCopyIconProps) => {
   const synapseContext = useSynapseContext()
   const queryContext = useQueryContext()
   const [isLoading, setIsLoading] = React.useState(false)
@@ -84,6 +89,7 @@ const EntityIDColumnCopyIcon = () => {
     <SynapseSpinner size={25} />
   ) : (
     <InteractiveCopyIdsIcon
+      {...props}
       onCopy={() => {
         handleCopyIdsToClipboard()
       }}

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
@@ -35,7 +35,7 @@ import loadingScreen from '../LoadingScreen'
 import ModalDownload from '../ModalDownload/ModalDownload'
 import { QueryVisualizationContextType } from '../QueryVisualizationWrapper'
 import { QueryContextType } from '../QueryContext/QueryContext'
-import { Icon } from '../row_renderers/utils'
+import IconSvg from '../IconSvg'
 import { SynapseTableCell } from '../synapse_table_functions/SynapseTableCell'
 import { Checkbox } from '../widgets/Checkbox'
 import { EnumFacetFilter } from '../widgets/query-filter/EnumFacetFilter'
@@ -716,13 +716,6 @@ export class SynapseTable extends React.Component<
           const isFacetSelection: boolean =
             facetIndex !== -1 && facets[facetIndex].facetType === 'enumeration'
           const facet = facets[facetIndex] as FacetColumnResultValues
-          const isSelectedSpanClass = isSelected
-            ? 'SRC-primary-background-color SRC-anchor-light'
-            : ''
-          const isSelectedIconClass = isSelected
-            ? 'SRC-selected-table-icon tool-icon'
-            : 'SRC-primary-text-color tool-icon'
-          const sortSpanBackgoundClass = `SRC-tableHead SRC-hand-cursor SRC-sortPadding SRC-primary-background-color-hover  ${isSelectedSpanClass}`
           const displayColumnName: string | undefined = getColumnDisplayName(
             column.name,
           )
@@ -763,8 +756,8 @@ export class SynapseTable extends React.Component<
                     <span
                       role="button"
                       aria-label="sort"
+                      aria-selected={isSelected}
                       tabIndex={0}
-                      className={sortSpanBackgoundClass}
                       onKeyPress={this.handleColumnSortPress({
                         index,
                         name: column.name,
@@ -774,16 +767,25 @@ export class SynapseTable extends React.Component<
                         name: column.name,
                       })}
                     >
-                      <Icon
-                        type={ICON_STATE[columnIndex]}
-                        cssClass={isSelectedIconClass}
-                      ></Icon>
+                      <IconSvg
+                        icon={ICON_STATE[columnIndex]}
+                        wrap={false}
+                        sx={{
+                          color: isSelected
+                            ? 'primary.contrastText'
+                            : 'primary.main',
+                          backgroundColor: isSelected ? 'primary.main' : 'none',
+
+                          '&:hover': {
+                            color: 'primary.contrastText',
+                            backgroundColor: 'primary.600',
+                          },
+                        }}
+                      />
                     </span>
                   )}
                   {isEntityIDColumn && (
-                    <span style={{ paddingBottom: '6px' }}>
-                      <EntityIDColumnCopyIcon />
-                    </span>
+                    <EntityIDColumnCopyIcon size={'small'} />
                   )}
                 </div>
               </div>

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableConstants.ts
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableConstants.ts
@@ -1,6 +1,8 @@
+import { IconName } from '../IconSvg'
+
 export const TOOLTIP_DELAY_SHOW = 500
 export const SELECT_ALL = 'SELECT_ALL'
 export const DESELECT_ALL = 'DESELECT_ALL'
 export const NOT_SET_DISPLAY_VALUE = '\u2013' // html dash
 // double check these icons!
-export const ICON_STATE: string[] = ['sortdown', 'sortdown', 'sortup']
+export const ICON_STATE: IconName[] = ['sortDown', 'sortDown', 'sortUp']

--- a/packages/synapse-react-client/src/style/base/_core.scss
+++ b/packages/synapse-react-client/src/style/base/_core.scss
@@ -112,28 +112,13 @@ svg.SRC-hoverBox {
     display: flex;
     text-align: left;
   }
-  .SRC-selected-table-icon {
-    svg {
-      width: 18px;
-      height: 18px;
-    }
-    svg,
-    path {
-      fill: #fff;
-    }
-  }
+
   .dropdown button.btn {
     margin: 0 1px;
     border: 0;
     border-radius: 0;
   }
-  .SRC-sortPadding {
-    padding: 3px;
-    margin: 0 1px;
-  }
-  .tool-icon {
-    display: flex;
-  }
+
   .SRC-primary-background-color-hover {
     &:hover,
     &[aria-expanded='true'] {
@@ -219,10 +204,6 @@ span.SRC-facets svg.SRC-facets-icon {
 
 .SRC-boldText {
   font-weight: bold;
-}
-
-a.SRC-anchor-light {
-  color: white;
 }
 
 .SRC-marginRightFivePx .SRC-paddingSevenPx {
@@ -356,10 +337,6 @@ button.SRC-roundBorder {
   font-size: 25px;
 }
 
-.SRC-selected-table-icon {
-  color: white;
-}
-
 .SRC-center-text {
   text-align: center;
 }
@@ -482,17 +459,6 @@ button.SRC-roundBorder {
   width: 0;
 }
 
-.SRC-tableHead {
-  font-size: 14px;
-  text-transform: capitalize;
-  font-weight: 700;
-}
-
-.SRC-sortPadding {
-  outline: none;
-  padding: 2px 3px;
-}
-
 .SRC-forceLeftDropdown {
   right: auto;
   left: 0;
@@ -527,13 +493,6 @@ button.SRC-roundBorder {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-}
-
-.SRC-tableHeader {
-  font-size: 18px;
-  margin: 0px;
-  display: inline-block;
-  color: white;
 }
 
 .SRC-hidden {

--- a/packages/synapse-react-client/src/style/components/_download-list-v2.scss
+++ b/packages/synapse-react-client/src/style/components/_download-list-v2.scss
@@ -6,15 +6,9 @@ table.DownloadListTableV2 {
   white-space: pre;
   .eligibileIcon {
     color: map.get(SRC.$colors, 'gray-800');
-    svg {
-      width: 15px;
-    }
   }
   .ineligibileIcon {
     color: map.get(SRC.$colors, 'warning');
-    svg {
-      width: 18px;
-    }
   }
   td.ineligibleForPackagingTd:first-child {
     background-color: #f9f5e7;

--- a/packages/synapse-react-client/stories/IconSvg.stories.tsx
+++ b/packages/synapse-react-client/stories/IconSvg.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   render: args => {
     return (
       <div style={{ display: 'flex', flexWrap: 'wrap', flexDirection: 'row' }}>
-        {IconStrings.sort().map(icon => (
+        {IconStrings.toSorted().map(icon => (
           <div style={{ margin: '10px', textAlign: 'center' }} key={icon}>
             <div>
               <IconSvg {...args} icon={icon} label={icon} />
@@ -27,8 +27,7 @@ export const Icon: Story = {
   args: {
     sx: {
       color: 'primary.main',
-      width: '40px',
-      height: '40px',
     },
+    fontSize: 'large',
   },
 }


### PR DESCRIPTION
- Refactor IconSvg to accept any MUI SvgIcon props
- InteractiveCopyIdsIcon now accepts MUI IconButton props
- Sort icons now accessible through IconSvg
- Fix viewboxes to center icons: SortUp, SoryDown, Docker, PackagableFile
- Use IconSvgProps/sx to drive styling for sort and copy buttons in SynapseTable column headers
- Tweak download cart CSS and icon display to account for packageableFile icon now being centered
- use toLocaleString and pluralize for download cart stats